### PR TITLE
Add popup UI for easier use

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -7,60 +7,86 @@ const targetAdIds = [
   "POKER_BAAZI",
   "POLICY_BAZAAR",
   "PR-25-011191_TATAIPL2025_IPL18_ipl18HANGOUTEVR20sEng_English_VCTA_NA", //sidhu ipl ad
-  "PR-25-012799_TATAIPL2025_IPL18_IPL18BHOJPURI20sBHOmob_Hindi_VCTA_20"
+  "PR-25-012799_TATAIPL2025_IPL18_IPL18BHOJPURI20sBHOmob_Hindi_VCTA_20",
 ];
 
-const MUTE_ALL_ADS = false; // Set to true to mute all ads
-
 const durationRegexes = [
-  /(\d{1,3})s(?:Eng(?:lish)?|Hin(?:di)?)/i,      // "20sEng", "15sHindi", "10sHin"
-  /(?:HIN|ENG|HINDI|ENGLISH)[^\d]*(\d{1,3})/i    // "HIN_10", "ENG_15"
+  /(\d{1,3})s(?:Eng(?:lish)?|Hin(?:di)?)/i, // "20sEng", "15sHindi", "10sHin"
+  /(?:HIN|ENG|HINDI|ENGLISH)[^\d]*(\d{1,3})/i, // "HIN_10", "ENG_15"
 ];
 
 console.log("Hotstar Adblocker extension loaded");
+
+// init defaults once
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.sync.get(["targetAdIds", "MUTE_ALL_ADS"], (data) => {
+    if (!data.targetAdIds)
+      chrome.storage.sync.set({ targetAdIds: targetAdIds });
+    if (data.MUTE_ALL_ADS === undefined)
+      chrome.storage.sync.set({ MUTE_ALL_ADS: false });
+  });
+});
+
+async function muteTabForAd(tab, durationSec) {
+  if (!tab.mutedInfo.muted) {
+    chrome.tabs.update(tab.id, { muted: true });
+    setTimeout(() => {
+      chrome.tabs.get(tab.id, (updatedTab) => {
+        if (updatedTab && updatedTab.mutedInfo.muted) {
+          chrome.tabs.update(tab.id, { muted: false });
+        }
+      });
+    }, durationSec * 1000 - 100);
+  }
+}
 
 chrome.webRequest.onBeforeRequest.addListener(
   async (details) => {
     const url = new URL(details.url);
     const adName = url.searchParams.get("adName");
     console.log(`Ad id: ${adName}`);
+    if (!adName) return;
 
-    if (adName) {
-      const adIdMatch = MUTE_ALL_ADS || targetAdIds.some((id) => adName.includes(id));
+    chrome.storage.sync.get(["targetAdIds", "MUTE_ALL_ADS"], async (data) => {
+      const { targetAdIds, MUTE_ALL_ADS } = data;
+      const shouldMute =
+        MUTE_ALL_ADS || targetAdIds.some((id) => adName.includes(id));
+      if (!shouldMute) return;
 
-      if (adIdMatch) {
-        let durationSec = 10;
-        for (const regex of durationRegexes) {
-          const match = adName.match(regex);
-          if (match) {
-            durationSec = parseInt(match[1], 10);
-            break;
-          }
-        }
-
-        console.log(`Muting ${adName} for ${durationSec} seconds`);
-
-        const tabs = await chrome.tabs.query({ url: "*://*.hotstar.com/*" });
-
-        for (const tab of tabs) {
-          if (!tab.mutedInfo.muted) {
-            chrome.tabs.update(tab.id, { muted: true });
-          //  console.log(`Muted tab ${tab.id}`);
-
-            setTimeout(() => {
-              chrome.tabs.get(tab.id, (updatedTab) => {
-                if (updatedTab && updatedTab.mutedInfo.muted) {
-                  chrome.tabs.update(tab.id, { muted: false });
-                //  console.log(`Unmuted tab ${tab.id}`);
-                }
-              });
-            }, (durationSec * 1000) - 100); // some buffer for next tracking pixel
-          }
+      let durationSec = 10;
+      for (const regex of durationRegexes) {
+        const match = adName.match(regex);
+        if (match) {
+          durationSec = parseInt(match[1], 10);
+          break;
         }
       }
-    }
+
+      console.log(`Muting ${adName} for ${durationSec} seconds`);
+      const tabs = await chrome.tabs.query({ url: "*://*.hotstar.com/*" });
+      for (const tab of tabs) {
+        muteTabForAd(tab, durationSec);
+      }
+    });
   },
-  {
-    urls: ["*://bifrost-api.hotstar.com/v1/events/track/ct_impression*"]
-  }
+  { urls: ["*://bifrost-api.hotstar.com/v1/events/track/ct_impression*"] }
 );
+
+// handle events from popup
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "updateMuteAll") {
+    console.log("Mute All Ads updated:", msg.value);
+    chrome.storage.sync.set({ MUTE_ALL_ADS: msg.value });
+  }
+
+  if (msg.type === "updateAdList") {
+    console.log("Ad list updated:", msg.value);
+    chrome.storage.sync.set({ targetAdIds: msg.value });
+
+    chrome.tabs.query({ url: "*://*.hotstar.com/*" }, (tabs) => {
+      tabs.forEach((tab) => {
+        chrome.tabs.sendMessage(tab.id, { type: "checkAndMuteAds" });
+      });
+    });
+  }
+});

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -6,11 +6,11 @@
   "permissions": [
     "storage",
     "tabs",
-    "webRequest",
-    "webRequestBlocking"
+    "webRequest"
   ],
   "host_permissions": [
-    "*://*.hotstar.com/*"
+    "*://*.hotstar.com/*",
+    "*://bifrost-api.hotstar.com/*"
   ],
   "background": {
     "service_worker": "background.js"

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,18 +1,25 @@
 {
   "manifest_version": 3,
   "name": "Hotstar Ad Muter",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Mute Hotstar ads",
   "permissions": [
+    "storage",
+    "tabs",
     "webRequest",
-    "tabs"
+    "webRequestBlocking"
   ],
-  "host_permissions": ["*://*.hotstar.com/*"],
+  "host_permissions": [
+    "*://*.hotstar.com/*"
+  ],
   "background": {
     "service_worker": "background.js"
   },
   "icons": {
     "48": "48.png",
     "128": "128.png"
+  },
+  "action": {
+    "default_popup": "popup.html"
   }
 }

--- a/chrome/popup.css
+++ b/chrome/popup.css
@@ -1,0 +1,200 @@
+body {
+  font-family: "Inter", system-ui, sans-serif;
+  background-color: #252833;
+  color: #fff;
+  width: 300px;
+  padding: 15px;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+header img {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+}
+
+header h1 {
+  font-size: 1.1rem;
+  margin: 0;
+  font-weight: 600;
+  color: #fff;
+}
+
+.settings {
+  background: #252833;
+  border-radius: 10px;
+  padding: 10px 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.switch-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.switch-label span {
+  font-size: 0.95rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #555;
+  transition: 0.3s;
+  border-radius: 22px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: 0.3s;
+}
+
+input:checked + .slider {
+  background-color: #007aff;
+}
+
+input:checked + .slider:before {
+  transform: translateX(18px);
+}
+
+.ad-section {
+  background: #17181f;
+  border-radius: 10px;
+  padding: 10px 15px;
+}
+
+.ad-section h2 {
+  font-size: 0.95rem;
+  margin: 0 0 10px 0;
+  color: #fff;
+}
+
+#adList {
+  list-style: none;
+  padding: 0 10px 0 0;
+  margin: 0 0 10px 0;
+  max-height: 120px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #007aff #252833;
+}
+#adList li {
+  background: #252833;
+  border-radius: 6px;
+  padding: 5px 8px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  gap: 6px;
+  overflow-wrap: anywhere;
+}
+
+#adList li span {
+  flex: 1;
+  word-break: break-word;
+}
+
+#adList li button {
+  background: none;
+  border: none;
+  color: #ff5252;
+  font-size: 0.9rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+#adList li button:hover {
+  color: #ff7676;
+}
+
+#adList::-webkit-scrollbar {
+  width: 6px;
+}
+
+#adList::-webkit-scrollbar-track {
+  background: #1a1f4b;
+  border-radius: 3px;
+}
+
+#adList::-webkit-scrollbar-thumb {
+  background: #007aff;
+  border-radius: 3px;
+}
+
+#adList::-webkit-scrollbar-thumb:hover {
+  background: #00b0ff;
+}
+.add-form {
+  display: flex;
+  gap: 6px;
+}
+
+#newAdId {
+  flex: 1;
+  padding: 6px;
+  border: none;
+  border-radius: 6px;
+  outline: none;
+  font-size: 0.85rem;
+}
+
+#addAdBtn {
+  background: linear-gradient(90deg, #007aff, #ff00b8);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.3s ease;
+}
+
+#addAdBtn:hover {
+  background: linear-gradient(90deg, #005fcc, #e600a0);
+}
+
+footer {
+  text-align: center;
+  font-size: 0.7rem;
+  color: #fff;
+  margin-top: 10px;
+}

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hotstar Ad Muter</title>
+  <link rel="stylesheet" href="popup.css" />
+</head>
+
+<body>
+  <header>
+    <img src="48.png" alt="Hotstar Ad Muter Icon" />
+    <h1>Hotstar Ad Muter</h1>
+  </header>
+
+  <section class="settings">
+    <label class="switch-label">
+      <span>Mute All Ads</span>
+      <label class="switch">
+        <input type="checkbox" id="muteAllToggle" />
+        <span class="slider"></span>
+      </label>
+    </label>
+  </section>
+
+  <section class="ad-section">
+    <h2>Blocked Ad IDs</h2>
+    <ul id="adList"></ul>
+
+    <div class="add-form">
+      <input type="text" id="newAdId" placeholder="Add new Ad ID" />
+      <button id="addAdBtn">Add</button>
+    </div>
+  </section>
+
+  <script src="popup.js"></script>
+</body>
+
+</html>

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -1,0 +1,57 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const muteAllToggle = document.getElementById("muteAllToggle");
+  const adList = document.getElementById("adList");
+  const newAdIdInput = document.getElementById("newAdId");
+  const addAdBtn = document.getElementById("addAdBtn");
+
+  chrome.storage.sync.get(["MUTE_ALL_ADS", "targetAdIds"], (data) => {
+    muteAllToggle.checked = data.MUTE_ALL_ADS || false;
+    renderAdList(data.targetAdIds || []);
+  });
+
+  muteAllToggle.addEventListener("change", () => {
+    const value = muteAllToggle.checked;
+    chrome.storage.sync.set({ MUTE_ALL_ADS: value }, () => {
+      console.log("Mute All Ads setting saved:", value);
+      chrome.runtime.sendMessage({ type: "updateMuteAll", value });
+    });
+  });
+
+  addAdBtn.addEventListener("click", () => {
+    const newAdId = newAdIdInput.value.trim();
+    if (!newAdId) return;
+
+    chrome.storage.sync.get("targetAdIds", (data) => {
+      const updated = [...(data.targetAdIds || []), newAdId];
+      chrome.storage.sync.set({ targetAdIds: updated }, () => {
+        renderAdList(updated);
+        chrome.runtime.sendMessage({ type: "updateAdList", value: updated });
+      });
+    });
+
+    newAdIdInput.value = "";
+  });
+
+  function renderAdList(ids) {
+    adList.innerHTML = "";
+    ids.forEach((id) => {
+      const li = document.createElement("li");
+      const span = document.createElement("span");
+      span.textContent = id;
+      li.appendChild(span);
+
+      const btn = document.createElement("button");
+      btn.textContent = "✕";
+      btn.addEventListener("click", () => {
+        const updated = ids.filter((x) => x !== id);
+        chrome.storage.sync.set({ targetAdIds: updated }, () => {
+          renderAdList(updated);
+          chrome.runtime.sendMessage({ type: "updateAdList", value: updated });
+        });
+      });
+
+      li.appendChild(btn);
+      adList.appendChild(li);
+    });
+  }
+});

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -8,9 +8,7 @@ const targetAdIds = [
   "POLICY_BAZAAR",
   "PR-25-011191_TATAIPL2025_IPL18_ipl18HANGOUTEVR20sEng_English_VCTA_NA", //sidhu ipl ad
   "PR-25-012799_TATAIPL2025_IPL18_IPL18BHOJPURI20sBHOmob_Hindi_VCTA_20"
-]
-
-const MUTE_ALL_ADS = false; // Set to true to mute all ads
+];
 
 const durationRegexes = [
   /(\d{1,3})s(?:Eng(?:lish)?|Hin(?:di)?)/i,      // "20sEng", "15sHindi", "10sHin"
@@ -19,16 +17,84 @@ const durationRegexes = [
 
 console.log("Hotstar Adblocker extension loaded");
 
+// init defaults
+function initDefaults() {
+  browser.storage.local.get(["targetAdIds", "MUTE_ALL_ADS"]).then((data) => {
+    console.log("Current storage:", data);
+    const updates = {};
+    
+    if (!data.targetAdIds || data.targetAdIds.length === 0) {
+      updates.targetAdIds = targetAdIds;
+      console.log("Setting default ad IDs");
+    }
+    
+    if (data.MUTE_ALL_ADS === undefined) {
+      updates.MUTE_ALL_ADS = false;
+      console.log("Setting default MUTE_ALL_ADS");
+    }
+    
+    if (Object.keys(updates).length > 0) {
+      browser.storage.local.set(updates).then(() => {
+        console.log("Defaults saved:", updates);
+      });
+    }
+  }).catch((err) => {
+    console.error("Error initializing defaults:", err);
+  });
+}
+
+initDefaults();
+
+browser.runtime.onInstalled.addListener(() => {
+  console.log("Extension installed/updated");
+  initDefaults();
+});
+
+function muteTabForAd(tab, durationSec) {
+  console.log(`Attempting to mute tab ${tab.id} for ${durationSec}s`);
+  
+  if (!tab.mutedInfo || !tab.mutedInfo.muted) {
+    browser.tabs.update(tab.id, { muted: true }).then(() => {
+      console.log(`Tab ${tab.id} muted successfully`);
+      
+      setTimeout(() => {
+        browser.tabs.get(tab.id).then((updatedTab) => {
+          if (updatedTab && updatedTab.mutedInfo && updatedTab.mutedInfo.muted) {
+            browser.tabs.update(tab.id, { muted: false }).then(() => {
+              console.log(`Tab ${tab.id} unmuted after ${durationSec}s`);
+            });
+          }
+        }).catch((err) => {
+          console.log("Tab no longer exists:", err);
+        });
+      }, durationSec * 1000 - 100);
+    }).catch((err) => {
+      console.error("Error muting tab:", err);
+    });
+  }
+}
+
 browser.webRequest.onBeforeRequest.addListener(
-  async (details) => {
-    const url = new URL(details.url);
-    const adName = url.searchParams.get("adName");
-    console.log(`Ad id: ${adName}`);
+  (details) => {
+    try {
+      const url = new URL(details.url);
+      const adName = url.searchParams.get("adName");
+      console.log(`Ad id: ${adName}`);
+      
+      if (!adName) return;
 
-    if (adName) {
-      const adIdMatch = MUTE_ALL_ADS || targetAdIds.some((id) => adName.includes(id));
+      browser.storage.local.get(["targetAdIds", "MUTE_ALL_ADS"]).then((data) => {
+        console.log("Storage data:", data);
+        
+        const storedAdIds = data.targetAdIds || [];
+        const muteAll = data.MUTE_ALL_ADS || false;
+        
+        const shouldMute = muteAll || storedAdIds.some((id) => adName.includes(id));
+        
+        console.log(`Should mute: ${shouldMute} (muteAll: ${muteAll})`);
+        
+        if (!shouldMute) return;
 
-      if (adIdMatch) {
         let durationSec = 10;
         for (const regex of durationRegexes) {
           const match = adName.match(regex);
@@ -40,27 +106,49 @@ browser.webRequest.onBeforeRequest.addListener(
 
         console.log(`Muting ${adName} for ${durationSec} seconds`);
 
-        const tabs = await browser.tabs.query({ url: "*://*.hotstar.com/*" });
-
-        for (const tab of tabs) {
-          if (!tab.mutedInfo.muted) {
-            browser.tabs.update(tab.id, { muted: true });
-          //  console.log(`Muted tab ${tab.id}`);
-
-            setTimeout(() => {
-              browser.tabs.get(tab.id, (updatedTab) => {
-                if (updatedTab && updatedTab.mutedInfo.muted) {
-                  browser.tabs.update(tab.id, { muted: false });
-                //  console.log(`Unmuted tab ${tab.id}`);
-                }
-              });
-            }, (durationSec * 1000) - 100); // some buffer for next tracking pixel
+        
+        browser.tabs.query({ url: "*://*.hotstar.com/*" }).then((tabs) => {
+          console.log(`Found ${tabs.length} Hotstar tabs`);
+          for (const tab of tabs) {
+            muteTabForAd(tab, durationSec);
           }
-        }
-      }
+        });
+      }).catch((err) => {
+        console.error("Error reading storage:", err);
+      });
+    } catch (err) {
+      console.error("Error in webRequest listener:", err);
     }
   },
-  {
-    urls: ["*://bifrost-api.hotstar.com/v1/events/track/ct_impression*"]
-  }
+  { urls: ["*://bifrost-api.hotstar.com/v1/events/track/ct_impression*"] }
 );
+
+// handle popup events
+browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  console.log("Message received:", msg);
+  
+  if (msg.type === "updateMuteAll") {
+    console.log("Updating Mute All Ads:", msg.value);
+    browser.storage.local.set({ MUTE_ALL_ADS: msg.value }).then(() => {
+      console.log("MUTE_ALL_ADS saved");
+      sendResponse({ success: true });
+    });
+    return true; 
+  }
+
+  if (msg.type === "updateAdList") {
+    console.log("Updating Ad list:", msg.value);
+    browser.storage.local.set({ targetAdIds: msg.value }).then(() => {
+      console.log("targetAdIds saved");
+      sendResponse({ success: true });
+    });
+    return true;
+  }
+  
+  if (msg.type === "getStatus") {
+    browser.storage.local.get(["targetAdIds", "MUTE_ALL_ADS"]).then((data) => {
+      sendResponse(data);
+    });
+    return true;
+  }
+});

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,19 +1,26 @@
 {
   "manifest_version": 2,
   "name": "Hotstar Ad Muter",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Mute Hotstar ads",
   "icons": {
     "48": "48.png",
     "128": "128.png"
   },
   "permissions": [
+    "storage",
     "tabs",
     "webRequest",
-    "*://*.hotstar.com/*"
+    "webRequestBlocking",
+    "*://*.hotstar.com/*",
+    "*://bifrost-api.hotstar.com/*"
+
   ],
   "background": {
     "scripts": ["background.js"],
     "persistent": true
+  },
+  "browser_action": {
+    "default_popup": "popup.html"
   }
 }

--- a/firefox/popup.css
+++ b/firefox/popup.css
@@ -1,0 +1,200 @@
+body {
+  font-family: "Inter", system-ui, sans-serif;
+  background-color: #252833;
+  color: #fff;
+  width: 300px;
+  padding: 15px;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+header img {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+}
+
+header h1 {
+  font-size: 1.1rem;
+  margin: 0;
+  font-weight: 600;
+  color: #fff;
+}
+
+.settings {
+  background: #252833;
+  border-radius: 10px;
+  padding: 10px 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.switch-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.switch-label span {
+  font-size: 0.95rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #555;
+  transition: 0.3s;
+  border-radius: 22px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: 0.3s;
+}
+
+input:checked + .slider {
+  background-color: #007aff;
+}
+
+input:checked + .slider:before {
+  transform: translateX(18px);
+}
+
+.ad-section {
+  background: #17181f;
+  border-radius: 10px;
+  padding: 10px 15px;
+}
+
+.ad-section h2 {
+  font-size: 0.95rem;
+  margin: 0 0 10px 0;
+  color: #fff;
+}
+
+#adList {
+  list-style: none;
+  padding: 0 10px 0 0;
+  margin: 0 0 10px 0;
+  max-height: 120px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #007aff #252833;
+}
+#adList li {
+  background: #252833;
+  border-radius: 6px;
+  padding: 5px 8px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  gap: 6px;
+  overflow-wrap: anywhere;
+}
+
+#adList li span {
+  flex: 1;
+  word-break: break-word;
+}
+
+#adList li button {
+  background: none;
+  border: none;
+  color: #ff5252;
+  font-size: 0.9rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+#adList li button:hover {
+  color: #ff7676;
+}
+
+#adList::-webkit-scrollbar {
+  width: 6px;
+}
+
+#adList::-webkit-scrollbar-track {
+  background: #1a1f4b;
+  border-radius: 3px;
+}
+
+#adList::-webkit-scrollbar-thumb {
+  background: #007aff;
+  border-radius: 3px;
+}
+
+#adList::-webkit-scrollbar-thumb:hover {
+  background: #00b0ff;
+}
+.add-form {
+  display: flex;
+  gap: 6px;
+}
+
+#newAdId {
+  flex: 1;
+  padding: 6px;
+  border: none;
+  border-radius: 6px;
+  outline: none;
+  font-size: 0.85rem;
+}
+
+#addAdBtn {
+  background: linear-gradient(90deg, #007aff, #ff00b8);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.3s ease;
+}
+
+#addAdBtn:hover {
+  background: linear-gradient(90deg, #005fcc, #e600a0);
+}
+
+footer {
+  text-align: center;
+  font-size: 0.7rem;
+  color: #fff;
+  margin-top: 10px;
+}

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hotstar Ad Muter</title>
+  <link rel="stylesheet" href="popup.css" />
+</head>
+
+<body>
+  <header>
+    <img src="48.png" alt="Hotstar Ad Muter Icon" />
+    <h1>Hotstar Ad Muter</h1>
+  </header>
+
+  <section class="settings">
+    <label class="switch-label">
+      <span>Mute All Ads</span>
+      <label class="switch">
+        <input type="checkbox" id="muteAllToggle" />
+        <span class="slider"></span>
+      </label>
+    </label>
+  </section>
+
+  <section class="ad-section">
+    <h2>Blocked Ad IDs</h2>
+    <ul id="adList"></ul>
+
+    <div class="add-form">
+      <input type="text" id="newAdId" placeholder="Add new Ad ID" />
+      <button id="addAdBtn">Add</button>
+    </div>
+  </section>
+
+  <script src="popup.js"></script>
+</body>
+
+</html>

--- a/firefox/popup.js
+++ b/firefox/popup.js
@@ -1,0 +1,108 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const muteAllToggle = document.getElementById("muteAllToggle");
+  const adList = document.getElementById("adList");
+  const newAdIdInput = document.getElementById("newAdId");
+  const addAdBtn = document.getElementById("addAdBtn");
+
+  console.log("Popup loaded");
+
+  function loadState() {
+    browser.storage.local.get(["MUTE_ALL_ADS", "targetAdIds"]).then((data) => {
+      console.log("Loaded from storage:", data);
+      
+      muteAllToggle.checked = data.MUTE_ALL_ADS || false;
+      const ids = data.targetAdIds || [];
+      renderAdList(ids);
+    }).catch((err) => {
+      console.error("Error loading state:", err);
+    });
+  }
+
+  loadState();
+
+  browser.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName === "local") {
+      console.log("Storage changed:", changes);
+      
+      if (changes.MUTE_ALL_ADS) {
+        muteAllToggle.checked = changes.MUTE_ALL_ADS.newValue || false;
+      }
+      
+      if (changes.targetAdIds) {
+        renderAdList(changes.targetAdIds.newValue || []);
+      }
+    }
+  });
+
+  muteAllToggle.addEventListener("change", () => {
+    const value = muteAllToggle.checked;
+    console.log("Toggle changed to:", value);
+    
+    browser.storage.local.set({ MUTE_ALL_ADS: value }).then(() => {
+      console.log("Mute All Ads setting saved:", value);
+      browser.runtime.sendMessage({ type: "updateMuteAll", value }).catch((err) => {
+        console.error("Error sending message:", err);
+      });
+    }).catch((err) => {
+      console.error("Error saving setting:", err);
+    });
+  });
+
+  addAdBtn.addEventListener("click", () => {
+    const newAdId = newAdIdInput.value.trim();
+    if (!newAdId) return;
+
+    console.log("Adding new ad ID:", newAdId);
+
+    browser.storage.local.get("targetAdIds").then((data) => {
+      const updated = [...(data.targetAdIds || []), newAdId];
+      console.log("Updated list:", updated);
+      
+      browser.storage.local.set({ targetAdIds: updated }).then(() => {
+        renderAdList(updated);
+        browser.runtime.sendMessage({ type: "updateAdList", value: updated }).catch((err) => {
+          console.error("Error sending message:", err);
+        });
+        newAdIdInput.value = "";
+      });
+    });
+  });
+
+  function renderAdList(ids) {
+    console.log("Rendering ad list:", ids);
+    adList.innerHTML = "";
+    
+    if (!ids || ids.length === 0) {
+      const li = document.createElement("li");
+      li.textContent = "No ad IDs configured";
+      li.style.fontStyle = "italic";
+      li.style.color = "#666";
+      adList.appendChild(li);
+      return;
+    }
+    
+    ids.forEach((id) => {
+      const li = document.createElement("li");
+      const span = document.createElement("span");
+      span.textContent = id;
+      li.appendChild(span);
+
+      const btn = document.createElement("button");
+      btn.textContent = "✕";
+      btn.addEventListener("click", () => {
+        console.log("Removing ad ID:", id);
+        const updated = ids.filter((x) => x !== id);
+        
+        browser.storage.local.set({ targetAdIds: updated }).then(() => {
+          renderAdList(updated);
+          browser.runtime.sendMessage({ type: "updateAdList", value: updated }).catch((err) => {
+            console.error("Error sending message:", err);
+          });
+        });
+      });
+
+      li.appendChild(btn);
+      adList.appendChild(li);
+    });
+  }
+});


### PR DESCRIPTION
Added a popup UI for the extensions to be able to mute all ads using a toggle switch and update the blocked ads lists aa well.

<img width="387" height="436" alt="image" src="https://github.com/user-attachments/assets/630909fe-13cd-44d9-b173-e3ec7aa179ad" />

Tested on Chrome `Version 141.0.7390.108` and Firefox `144.0 (64-bit)`

Chrome logs:
<img width="955" height="153" alt="image" src="https://github.com/user-attachments/assets/d60856b3-9b69-432b-b261-1c360cab096f" />

Firefox logs:

<img width="884" height="158" alt="image" src="https://github.com/user-attachments/assets/be3dc6b4-8d88-46b7-80f2-5845bf205a79" />


_Used GPT to convert the chrome scripts to firefox compatible scripts._